### PR TITLE
fix QT 5.5.1 compilation

### DIFF
--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -36,6 +36,7 @@
 #include "AudioInput.h"
 #include "AudioOutput.h"
 
+#include <QtCore/QWaitCondition>
 #include <jack/jack.h>
 
 class JackAudioOutput;


### PR DESCRIPTION
compiling with QT 5.5.1 led to the following error messages:
In file included from release/moc_JackAudio.cpp:9:0:
release/../JackAudio.h:62:3: error: 'QWaitCondition' does not name a type
   QWaitCondition m_waitCondition;
   ^
release/../JackAudio.h:88:3: error: 'QWaitCondition' does not name a type
   QWaitCondition m_waitCondition;
   ^
release/../JackAudio.h:105:3: error: 'QWaitCondition' does not name a type
   QWaitCondition m_waitCondition;
   ^
